### PR TITLE
Extracted circular buffer logic into dedicated types

### DIFF
--- a/src/logic/copy.rs
+++ b/src/logic/copy.rs
@@ -1,0 +1,144 @@
+use super::CircularBuffer;
+
+pub struct Parameters {
+    pub dst: usize,
+    pub src: usize,
+    pub len: usize,
+    pub dst_after_src: bool,
+    pub src_pre_wrap_len: usize,
+    pub dst_pre_wrap_len: usize,
+    pub src_wraps: bool,
+    pub dst_wraps: bool,
+}
+
+pub struct Wrapping;
+
+impl Wrapping {
+    /// Copies a potentially wrapping block of memory len long from src to dest.
+    /// (abs(dst - src) + len) must be no larger than cap() (There must be at
+    /// most one continuous overlapping region between src and dest).
+    pub unsafe fn wrap_copy<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        let Parameters { dst_after_src, src_wraps, dst_wraps, .. } = params;
+        match (dst_after_src, src_wraps, dst_wraps) {
+            (_, false, false) => Self::none_wrap(buffer, params),
+            (false, false, true) => Self::dst_wraps(buffer, params),
+            (true, false, true) => Self::dst_after_src_dst_wraps(buffer, params),
+            (false, true, false) => Self::src_wraps(buffer, params),
+            (true, true, false) => Self::dst_after_src_src_wraps(buffer, params),
+            (false, true, true) => Self::src_wraps_dst_wraps(buffer, params),
+            (true, true, true) => Self::dst_after_src_src_wraps_dst_wraps(buffer, params),
+        }
+    }
+
+    unsafe fn none_wrap<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // src doesn't wrap, dst doesn't wrap
+        //
+        //        S . . .
+        // 1 [_ _ A A B B C C _]
+        // 2 [_ _ A A A A B B _]
+        //            D . . .
+        //
+
+        let Parameters { dst, src, len, .. } = params;
+        buffer.copy(dst, src, len);
+    }
+
+    unsafe fn dst_wraps<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // dst before src, src doesn't wrap, dst wraps
+        //
+        //    S . . .
+        // 1 [A A B B _ _ _ C C]
+        // 2 [A A B B _ _ _ A A]
+        // 3 [B B B B _ _ _ A A]
+        //    . .           D .
+        //
+
+        let Parameters { dst, src, len, dst_pre_wrap_len, .. } = params;
+        buffer.copy(dst, src, dst_pre_wrap_len);
+        buffer.copy(0, src + dst_pre_wrap_len, len - dst_pre_wrap_len);
+    }
+
+    unsafe fn dst_after_src_dst_wraps<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // src before dst, src doesn't wrap, dst wraps
+        //
+        //              S . . .
+        // 1 [C C _ _ _ A A B B]
+        // 2 [B B _ _ _ A A B B]
+        // 3 [B B _ _ _ A A A A]
+        //    . .           D .
+        //
+
+        let Parameters { dst, src, len, dst_pre_wrap_len, .. } = params;
+        buffer.copy(0, src + dst_pre_wrap_len, len - dst_pre_wrap_len);
+        buffer.copy(dst, src, dst_pre_wrap_len);
+    }
+
+    unsafe fn src_wraps<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // dst before src, src wraps, dst doesn't wrap
+        //
+        //    . .           S .
+        // 1 [C C _ _ _ A A B B]
+        // 2 [C C _ _ _ B B B B]
+        // 3 [C C _ _ _ B B C C]
+        //              D . . .
+        //
+
+        let Parameters { dst, src, len, src_pre_wrap_len, .. } = params;
+        buffer.copy(dst, src, src_pre_wrap_len);
+        buffer.copy(dst + src_pre_wrap_len, 0, len - src_pre_wrap_len);
+    }
+
+    unsafe fn dst_after_src_src_wraps<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // src before dst, src wraps, dst doesn't wrap
+        //
+        //    . .           S .
+        // 1 [A A B B _ _ _ C C]
+        // 2 [A A A A _ _ _ C C]
+        // 3 [C C A A _ _ _ C C]
+        //    D . . .
+        //
+
+        let Parameters { dst, src, len, src_pre_wrap_len, .. } = params;
+        buffer.copy(dst + src_pre_wrap_len, 0, len - src_pre_wrap_len);
+        buffer.copy(dst, src, src_pre_wrap_len);
+    }
+
+    unsafe fn src_wraps_dst_wraps<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // dst before src, src wraps, dst wraps
+        //
+        //    . . .         S .
+        // 1 [A B C D _ E F G H]
+        // 2 [A B C D _ E G H H]
+        // 3 [A B C D _ E G H A]
+        // 4 [B C C D _ E G H A]
+        //    . .         D . .
+        //
+
+        let Parameters { dst, src, len, src_pre_wrap_len, dst_pre_wrap_len, .. } = params;
+        debug_assert!(dst_pre_wrap_len > src_pre_wrap_len);
+        let delta = dst_pre_wrap_len - src_pre_wrap_len;
+        buffer.copy(dst, src, src_pre_wrap_len);
+        buffer.copy(dst + src_pre_wrap_len, 0, delta);
+        buffer.copy(0, delta, len - dst_pre_wrap_len);
+    }
+
+    unsafe fn dst_after_src_src_wraps_dst_wraps<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // src before dst, src wraps, dst wraps
+        //
+        //    . .         S . .
+        // 1 [A B C D _ E F G H]
+        // 2 [A A B D _ E F G H]
+        // 3 [H A B D _ E F G H]
+        // 4 [H A B D _ E F F G]
+        //    . . .         D .
+        //
+
+        let Parameters { dst, src, len, src_pre_wrap_len, dst_pre_wrap_len, .. } = params;
+        debug_assert!(src_pre_wrap_len > dst_pre_wrap_len);
+        let array_len = buffer.array_len();
+        let delta = src_pre_wrap_len - dst_pre_wrap_len;
+        buffer.copy(delta, 0, len - src_pre_wrap_len);
+        buffer.copy(0, array_len - delta, delta);
+        buffer.copy(dst, src, dst_pre_wrap_len);
+    }
+}

--- a/src/logic/insert.rs
+++ b/src/logic/insert.rs
@@ -1,0 +1,227 @@
+use super::CircularBuffer;
+
+pub struct Parameters {
+    pub index: usize,
+    pub internal_index: usize,
+    pub distance_to_tail: usize,
+    pub distance_to_head: usize,
+}
+
+pub struct Contiguous;
+
+impl Contiguous {
+    #[inline]
+    pub unsafe fn insert<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        let Parameters { index, distance_to_tail, distance_to_head, ..} = params;
+        match distance_to_tail <= distance_to_head {
+            true if index == 0 => Self::closer_to_tail_at_zero(buffer),
+            true => Self::closer_to_tail(buffer, params),
+            false => Self::closer_to_head(buffer, params),
+        }
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail_at_zero<B: CircularBuffer>(buffer: &mut B) {
+        // contiguous, insert closer to tail, at zero:
+        //
+        //       T
+        //       I             H
+        //      [A o o o o o o . . . . . . . . .]
+        //
+        //                       H         T
+        //      [A o o o o o o o . . . . . I]
+        //
+
+        let new_tail = B::wrap_sub(buffer.tail(), 1);
+        buffer.set_tail(new_tail)
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // contiguous, insert closer to tail:
+        //
+        //             T   I         H
+        //      [. . . o o A o o o o . . . . . .]
+        //
+        //           T               H
+        //      [. . o o I A o o o o . . . . . .]
+        //           M M
+        //
+        // contiguous, insert closer to tail and tail is 0:
+        //
+        //
+        //       T   I         H
+        //      [o o A o o o o . . . . . . . . .]
+        //
+        //                       H             T
+        //      [o I A o o o o o . . . . . . . o]
+        //       M                             M
+
+        let Parameters { index, ..} = params;
+
+        let tail = buffer.tail();
+        let new_tail = B::wrap_sub(buffer.tail(), 1);
+
+        buffer.copy(new_tail, tail, 1);
+        // Already moved the tail, so we only copy `index - 1` elements.
+        buffer.copy(tail, tail + 1, index - 1);
+
+        buffer.set_tail(new_tail);
+    }
+
+    #[inline]
+    unsafe fn closer_to_head<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        //  contiguous, insert closer to head:
+        //
+        //             T       I     H
+        //      [. . . o o o o A o o . . . . . .]
+        //
+        //             T               H
+        //      [. . . o o o o I A o o . . . . .]
+        //                       M M M
+
+        let Parameters { internal_index, ..} = params;
+        let head = buffer.head();
+        buffer.copy(internal_index + 1, internal_index, head - internal_index);
+        let new_head = B::wrap_add(buffer.head(), 1);
+        buffer.set_head(new_head);
+    }
+}
+
+pub struct Discontiguous;
+
+impl Discontiguous {
+    #[inline]
+    pub unsafe fn insert<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        let Parameters { internal_index, distance_to_tail, distance_to_head, ..} = params;
+        match (distance_to_tail <= distance_to_head, internal_index >= buffer.tail()) {
+            (true, true) => Self::closer_to_tail_tail_section(buffer, params),
+            (true, false) => Self::closer_to_tail(buffer, params),
+            (false, true) => Self::closer_to_head_tail_section(buffer, params),
+            (false, false) => Self::closer_to_head_head_section(buffer, params),
+        }
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        let Parameters { internal_index, ..} = params;
+
+        if internal_index == 0 {
+            Self::closer_to_tail_head_section_at_zero(buffer);
+        } else {
+            Self::closer_to_tail_head_section(buffer, params);
+        }
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail_tail_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, insert closer to tail, tail section:
+        //
+        //                   H         T   I
+        //      [o o o o o o . . . . . o o A o o]
+        //
+        //                   H       T
+        //      [o o o o o o . . . . o o I A o o]
+        //                           M M
+
+        let Parameters { index, ..} = params;
+        let tail = buffer.tail();
+        buffer.copy(tail - 1, tail, index);
+        buffer.set_tail(tail - 1);
+    }
+
+    #[inline]
+    unsafe fn closer_to_head_tail_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, insert closer to head, tail section:
+        //
+        //           H             T         I
+        //      [o o . . . . . . . o o o o o A o]
+        //
+        //             H           T
+        //      [o o o . . . . . . o o o o o I A]
+        //       M M M                         M
+
+        let Parameters { internal_index, ..} = params;
+        let array_len = buffer.array_len();
+
+        // copy elements up to new head
+        let head = buffer.head();
+        buffer.copy(1, 0, head);
+
+        // copy last element into empty spot at bottom of buffer
+        buffer.copy(0, array_len - 1, 1);
+
+        // move elements from internal_index to end forward not including ^ element
+        buffer.copy(internal_index + 1, internal_index, array_len - 1 - internal_index);
+
+        buffer.set_head(head + 1);
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail_head_section_at_zero<B: CircularBuffer>(buffer: &mut B) {
+        // discontiguous, insert is closer to tail, head section,
+        // and is at index zero in the internal buffer:
+        //
+        //       I                   H     T
+        //      [A o o o o o o o o o . . . o o o]
+        //
+        //                           H   T
+        //      [A o o o o o o o o o . . o o o I]
+        //                               M M M
+
+        let array_len = buffer.array_len();
+
+        // copy elements up to new tail
+        let tail = buffer.tail();
+        buffer.copy(tail - 1, tail, array_len - tail);
+
+        // copy last element into empty spot at bottom of buffer
+        buffer.copy(array_len - 1, 0, 1);
+
+        buffer.set_tail(tail - 1);
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail_head_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, insert closer to tail, head section:
+        //
+        //             I             H     T
+        //      [o o o A o o o o o o . . . o o o]
+        //
+        //                           H   T
+        //      [o o I A o o o o o o . . o o o o]
+        //       M M                     M M M M
+
+        let Parameters { internal_index, ..} = params;
+        let array_len = buffer.array_len();
+
+        let tail = buffer.tail();
+        // copy elements up to new tail
+        buffer.copy(tail - 1, tail, array_len - tail);
+
+        // copy last element into empty spot at bottom of buffer
+        buffer.copy(array_len - 1, 0, 1);
+
+        // move elements from internal_index-1 to end forward not including ^ element
+        buffer.copy(0, 1, internal_index - 1);
+
+        buffer.set_tail(tail - 1);
+    }
+
+    #[inline]
+    unsafe fn closer_to_head_head_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, insert closer to head, head section:
+        //
+        //               I     H           T
+        //      [o o o o A o o . . . . . . o o o]
+        //
+        //                     H           T
+        //      [o o o o I A o o . . . . . o o o]
+        //                 M M M
+
+        let Parameters { internal_index, ..} = params;
+        let head = buffer.head();
+        buffer.copy(internal_index + 1, internal_index, head - internal_index);
+        buffer.set_head(head + 1);
+    }
+}

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -1,0 +1,18 @@
+pub mod insert;
+pub mod remove;
+pub mod copy;
+
+pub trait CircularBuffer {
+    fn array_len(&self) -> usize;
+
+    fn head(&self) -> usize;
+    fn tail(&self) -> usize;
+
+    unsafe fn set_head(&mut self, head: usize);
+    unsafe fn set_tail(&mut self, tail: usize);
+
+    unsafe fn copy(&mut self, dst: usize, src: usize, len: usize);
+
+    fn wrap_add(index: usize, addend: usize) -> usize;
+    fn wrap_sub(index: usize, subtrahend: usize) -> usize;
+}

--- a/src/logic/remove.rs
+++ b/src/logic/remove.rs
@@ -1,0 +1,172 @@
+use super::CircularBuffer;
+
+pub struct Parameters {
+    pub index: usize,
+    pub internal_index: usize,
+    pub distance_to_tail: usize,
+    pub distance_to_head: usize,
+}
+
+pub struct Contiguous;
+
+impl Contiguous {
+    pub unsafe fn remove<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        let Parameters { distance_to_tail, distance_to_head, ..} = params;
+        match distance_to_tail <= distance_to_head {
+            true => Self::closer_to_tail(buffer, params),
+            false => Self::closer_to_head(buffer, params),
+        }
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // contiguous, remove closer to tail:
+        //
+        //             T   R         H
+        //      [. . . o o x o o o o . . . . . .]
+        //
+        //               T           H
+        //      [. . . . o o o o o o . . . . . .]
+        //               M M
+
+        let Parameters { index, ..} = params;
+        let tail = buffer.tail();
+        buffer.copy(tail + 1, tail, index);
+        buffer.set_tail(tail + 1);
+    }
+
+    #[inline]
+    unsafe fn closer_to_head<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // contiguous, remove closer to head:
+        //
+        //             T       R     H
+        //      [. . . o o o o x o o . . . . . .]
+        //
+        //             T           H
+        //      [. . . o o o o o o . . . . . . .]
+        //                     M M
+
+        let Parameters { internal_index, ..} = params;
+        let head = buffer.head();
+        buffer.copy(internal_index, internal_index + 1, head - internal_index - 1);
+        buffer.set_head(head - 1);
+    }
+}
+
+pub struct Discontiguous;
+
+impl Discontiguous {
+    #[inline]
+    pub unsafe fn remove<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        let Parameters { internal_index, distance_to_tail, distance_to_head, ..} = params;
+        match (distance_to_tail <= distance_to_head, internal_index >= buffer.tail()) {
+            (true, true) => Self::closer_to_tail_tail_section(buffer, params),
+            (true, false) => Self::closer_to_tail_head_section(buffer, params),
+            (false, true) => Self::closer_to_head_tail_section(buffer, params),
+            (false, false) => Self::closer_to_head_head_section(buffer, params),
+        }
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail_tail_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, remove closer to tail, tail section:
+        //
+        //                   H         T   R
+        //      [o o o o o o . . . . . o o x o o]
+        //
+        //                   H           T
+        //      [o o o o o o . . . . . . o o o o]
+        //                               M M
+
+        let Parameters { index, ..} = params;
+        let tail = buffer.tail();
+        buffer.copy(tail + 1, tail, index);
+        let new_tail = B::wrap_add(buffer.tail(), 1);
+        buffer.set_tail(new_tail);
+    }
+
+    #[inline]
+    unsafe fn closer_to_head_tail_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, remove closer to head, tail section:
+        //
+        //             H           T         R
+        //      [o o o . . . . . . o o o o o x o]
+        //
+        //           H             T
+        //      [o o . . . . . . . o o o o o o o]
+        //       M M                         M M
+        //
+        // or quasi-discontiguous, remove next to head, tail section:
+        //
+        //       H                 T         R
+        //      [. . . . . . . . . o o o o o x o]
+        //
+        //                         T           H
+        //      [. . . . . . . . . o o o o o o .]
+        //                                   M
+
+        let Parameters { internal_index, ..} = params;
+        let array_len = buffer.array_len();
+
+        // draw in elements in the tail section
+        buffer.copy(internal_index, internal_index + 1, array_len - internal_index - 1);
+
+        // Prevents underflow.
+        if buffer.head() != 0 {
+            // copy first element into empty spot
+            buffer.copy(array_len - 1, 0, 1);
+
+            // move elements in the head section backwards
+            let head = buffer.head();
+            buffer.copy(0, 1, head - 1);
+        }
+
+        let new_head = B::wrap_sub(buffer.head(), 1);
+        buffer.set_head(new_head);
+    }
+
+    #[inline]
+    unsafe fn closer_to_tail_head_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, remove closer to tail, head section:
+        //
+        //           R               H     T
+        //      [o o x o o o o o o o . . . o o o]
+        //
+        //                           H       T
+        //      [o o o o o o o o o o . . . . o o]
+        //       M M M                       M M
+
+        let Parameters { internal_index, ..} = params;
+        let array_len = buffer.array_len();
+
+        let tail = buffer.tail();
+        // draw in elements up to internal_index
+        buffer.copy(1, 0, internal_index);
+
+        // copy last element into empty spot
+        buffer.copy(0, array_len - 1, 1);
+
+        // move elements from tail to end forward, excluding the last one
+        buffer.copy(tail + 1, tail, array_len - tail - 1);
+
+        let new_tail = B::wrap_add(tail, 1);
+        buffer.set_tail(new_tail);
+    }
+
+    #[inline]
+    unsafe fn closer_to_head_head_section<B: CircularBuffer>(buffer: &mut B, params: Parameters) {
+        // discontiguous, remove closer to head, head section:
+        //
+        //               R     H           T
+        //      [o o o o x o o . . . . . . o o o]
+        //
+        //                   H             T
+        //      [o o o o o o . . . . . . . o o o]
+        //               M M
+
+        let Parameters { internal_index, ..} = params;
+        let head = buffer.head();
+        buffer.copy(internal_index, internal_index + 1, head - internal_index - 1);
+        buffer.set_head(head - 1);
+    }
+}


### PR DESCRIPTION
In its current state `ArrayDeque<A>` contains three utterly long methods …

- `fn insert(&mut self, …)`
- `fn remove(&mut self, …)`
- `fn wrap_copy(&mut self, …)`

… which consist of each a huge `match`. 

I removed the `match`s, moved it into their own dedicated types and split them up some more.

With this change one can –in future– easily add finely-grained test cases for each `match` case, while in its current form each match is a huge blackbox.

Over time `ArrayDeque<A>` will grow some more.  
I managed to reduce `lib.rs` from 2633 to 2299 loc for now.