### PR TITLE
API towards v0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 matrix:
   include:
-    - rust: 1.15.0
+    - rust: 1.20.0
     - rust: stable
     - rust: beta
     - rust: nightly
@@ -18,13 +18,7 @@ branches:
 script:
   - |
       cargo test --verbose &&
-      cargo test --verbose --no-default-features &&
-      cargo test --verbose --features "use_generic_array" &&
-      cargo test --verbose --no-default-features --features "use_generic_array" &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --features "use_union") &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --features "use_union use_generic_array") &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --no-default-features --features "use_union") &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --no-default-features --features "use_union use_generic_array")
+      cargo test --verbose --no-default-features
 
 before_install:
   - sudo apt-get update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arraydeque"
-version = "0.2.3"
+version = "0.3.1"
 authors = ["goandylok"]
 license = "MIT/Apache-2.0"
 
@@ -15,16 +15,6 @@ keywords = ["ring", "circular", "stack", "array", "no_std"]
 version = "0.2.12"
 default-features = false
 
-[dependencies.nodrop]
-version = "0.1.8"
-default-features = false
-
-[dependencies.generic-array]
-version = "0.5.1"
-optional = true
-
 [features]
 default = ["std"]
-std = ["odds/std", "nodrop/std"]
-use_union = ["nodrop/use_union"]
-use_generic_array = ["generic-array"]
+std = ["odds/std"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crates.io](https://img.shields.io/crates/v/arraydeque.svg)](https://crates.io/crates/arraydeque)
 [![docs.rs](https://docs.rs/arraydeque/badge.svg)](https://docs.rs/arraydeque)
 
-A circular buffer with fixed capacity.  Requires Rust 1.15+.
+A circular buffer with fixed capacity.  Requires Rust 1.20+.
 
 This crate is inspired by [**bluss/arrayvec**](https://github.com/bluss/arrayvec)
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,6 +1,6 @@
 /// Trait for fixed size arrays.
 pub unsafe trait Array {
-    /// The array's element type
+    /// The array’s element type
     type Item;
     #[doc(hidden)]
     /// The smallest index type that indexes the array.
@@ -18,24 +18,6 @@ pub trait Index : PartialEq + Copy {
     fn from(usize) -> Self;
 }
 
-#[cfg(feature = "use_generic_array")]
-unsafe impl<T, U> Array for ::generic_array::GenericArray<T, U>
-    where U: ::generic_array::ArrayLength<T>
-{
-    type Item = T;
-    type Index = usize;
-    fn as_ptr(&self) -> *const Self::Item {
-        (**self).as_ptr()
-    }
-    fn as_mut_ptr(&mut self) -> *mut Self::Item {
-        (**self).as_mut_ptr()
-    }
-    fn capacity() -> usize {
-        U::to_usize()
-    }
-
-}
-
 impl Index for u8 {
     #[inline(always)]
     fn to_usize(self) -> usize { self as usize }
@@ -48,6 +30,13 @@ impl Index for u16 {
     fn to_usize(self) -> usize { self as usize }
     #[inline(always)]
     fn from(ix: usize) ->  Self { ix as u16 }
+}
+
+impl Index for u32 {
+    #[inline(always)]
+    fn to_usize(self) -> usize { self as usize }
+    #[inline(always)]
+    fn from(ix: usize) ->  Self { ix as u32 }
 }
 
 impl Index for usize {
@@ -82,5 +71,8 @@ macro_rules! fix_array_impl_recursive {
 
 fix_array_impl_recursive!(u8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                           16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                          32, 40, 48, 56, 64, 72, 96, 128, 160, 192, 224,);
+                          32, 40, 48, 50, 56, 64, 72, 96, 100, 128, 160, 192, 200, 224,);
 fix_array_impl_recursive!(u16, 256, 384, 512, 768, 1024, 2048, 4096, 8192, 16384, 32768,);
+// This array size doesn't exist on 16-bit
+#[cfg(any(target_pointer_width="32", target_pointer_width="64"))]
+fix_array_impl_recursive!(u32, 1 << 16,);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,30 @@
+use std::fmt;
+#[cfg(feature="std")]
+use std::error::Error;
+
+/// Error value indicating insufficient capacity
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CapacityError<T = ()> {
+    pub element: T,
+}
+
+const CAPERROR: &'static str = "insufficient capacity";
+
+#[cfg(feature="std")]
+impl<T> Error for CapacityError<T> {
+    fn description(&self) -> &str {
+        CAPERROR
+    }
+}
+
+impl<T> fmt::Display for CapacityError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", CAPERROR)
+    }
+}
+
+impl<T> fmt::Debug for CapacityError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", "CapacityError", CAPERROR)
+    }
+}

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -1,0 +1,3 @@
+/// A marker type that indicate a ArrayDeque will not 
+pub struct NoneWrapping;
+pub struct Wrapping;


### PR DESCRIPTION
Road map of the journey towards v0.3 API:

- [x] Remove `generic_array` support
- [x] Add `CapacityError` error type
- [x] Support 16-bit target
- [x] Deprecate `nodrop` and use `ManuallyDrop` instead, which will bump the minimal rust version to v1.20.
- [x] Improve document
- [x] Wrapping buffer behavior
- [ ] Document for wrapping buffer behavior
- [ ] Reorder document of functions 