### PR TITLE
[WIP] Behaviors: Saturating, Wrapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 matrix:
   include:
-    - rust: 1.15.0
+    - rust: 1.20.0
     - rust: stable
     - rust: beta
     - rust: nightly
@@ -18,13 +18,7 @@ branches:
 script:
   - |
       cargo test --verbose &&
-      cargo test --verbose --no-default-features &&
-      cargo test --verbose --features "use_generic_array" &&
-      cargo test --verbose --no-default-features --features "use_generic_array" &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --features "use_union") &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --features "use_union use_generic_array") &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --no-default-features --features "use_union") &&
-      ([ "$NIGHTLY" != 1 ] || cargo test --verbose --no-default-features --features "use_union use_generic_array")
+      cargo test --verbose --no-default-features
 
 before_install:
   - sudo apt-get update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arraydeque"
-version = "0.2.3"
+version = "0.3.1"
 authors = ["goandylok"]
 license = "MIT/Apache-2.0"
 
@@ -15,16 +15,6 @@ keywords = ["ring", "circular", "stack", "array", "no_std"]
 version = "0.2.12"
 default-features = false
 
-[dependencies.nodrop]
-version = "0.1.8"
-default-features = false
-
-[dependencies.generic-array]
-version = "0.5.1"
-optional = true
-
 [features]
 default = ["std"]
-std = ["odds/std", "nodrop/std"]
-use_union = ["nodrop/use_union"]
-use_generic_array = ["generic-array"]
+std = ["odds/std"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crates.io](https://img.shields.io/crates/v/arraydeque.svg)](https://crates.io/crates/arraydeque)
 [![docs.rs](https://docs.rs/arraydeque/badge.svg)](https://docs.rs/arraydeque)
 
-A circular buffer with fixed capacity.  Requires Rust 1.15+.
+A circular buffer with fixed capacity.  Requires Rust 1.20+.
 
 This crate is inspired by [**bluss/arrayvec**](https://github.com/bluss/arrayvec)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,34 @@ request this via:
 [dependencies]
 arraydeque = { version = "0.2", default-features = false }
 ```
+
+## Behaviors
+
+`ArrayDeque` is defined as `ArrayDeque<A: Array, B: Behavior = Saturating>`,
+with `A` being the backing buffer type and `B` being the deque's behavior.
+
+Possible types for `B: Behavior` are `Saturating` and `Wrapping`.
+
+### Default
+
+`Saturating` is the default behavior when using `ArrayDeque<A: Array>` without an explicit `B: Behavior`.
+
+### Saturating
+
+- **Pushing elements** to the **back** of a fixed-size deque that **has already reached its capacity**
+causes it **exit early, without performing any mutation**.
+- **Pushing elements** to the **front** of a fixed-size deque that **has already reached its capacity**
+causes it **exit early, without performing any mutation**.
+
+### Wrapping
+
+- **Pushing elements** to the **back** of a fixed-size deque that **has already reached its capacity**
+causes it to **overwrite** existing elements from the **front**.
+- **Pushing elements** to the **front** of a fixed-size deque that **has already reached its capacity**
+causes it to **overwrite** existing elements from the **back**.
+
+You find more specific descriptions of the behavior semantics in the corresponding API documentation.
+
 ## Capacity
 
 Note that the `capacity()` is always `backed_array.len() - 1`.

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,3 +1,5 @@
+//! Fixed-size arrays.
+
 /// Trait for fixed size arrays.
 pub unsafe trait Array {
     /// The array’s element type
@@ -13,8 +15,12 @@ pub unsafe trait Array {
     fn capacity() -> usize;
 }
 
+/// Trait for converting indices from/to `usize`.
 pub trait Index : PartialEq + Copy {
+    /// Convert from `T: Index` to `usize`.
     fn to_usize(self) -> usize;
+
+    /// Convert from `usize` to `T: Index`.
     fn from(usize) -> Self;
 }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,6 +1,6 @@
 /// Trait for fixed size arrays.
 pub unsafe trait Array {
-    /// The array's element type
+    /// The array’s element type
     type Item;
     #[doc(hidden)]
     /// The smallest index type that indexes the array.
@@ -18,24 +18,6 @@ pub trait Index : PartialEq + Copy {
     fn from(usize) -> Self;
 }
 
-#[cfg(feature = "use_generic_array")]
-unsafe impl<T, U> Array for ::generic_array::GenericArray<T, U>
-    where U: ::generic_array::ArrayLength<T>
-{
-    type Item = T;
-    type Index = usize;
-    fn as_ptr(&self) -> *const Self::Item {
-        (**self).as_ptr()
-    }
-    fn as_mut_ptr(&mut self) -> *mut Self::Item {
-        (**self).as_mut_ptr()
-    }
-    fn capacity() -> usize {
-        U::to_usize()
-    }
-
-}
-
 impl Index for u8 {
     #[inline(always)]
     fn to_usize(self) -> usize { self as usize }
@@ -48,6 +30,13 @@ impl Index for u16 {
     fn to_usize(self) -> usize { self as usize }
     #[inline(always)]
     fn from(ix: usize) ->  Self { ix as u16 }
+}
+
+impl Index for u32 {
+    #[inline(always)]
+    fn to_usize(self) -> usize { self as usize }
+    #[inline(always)]
+    fn from(ix: usize) ->  Self { ix as u32 }
 }
 
 impl Index for usize {
@@ -82,5 +71,8 @@ macro_rules! fix_array_impl_recursive {
 
 fix_array_impl_recursive!(u8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                           16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                          32, 40, 48, 56, 64, 72, 96, 128, 160, 192, 224,);
+                          32, 40, 48, 50, 56, 64, 72, 96, 100, 128, 160, 192, 200, 224,);
 fix_array_impl_recursive!(u16, 256, 384, 512, 768, 1024, 2048, 4096, 8192, 16384, 32768,);
+// This array size doesn't exist on 16-bit
+#[cfg(any(target_pointer_width="32", target_pointer_width="64"))]
+fix_array_impl_recursive!(u32, 1 << 16,);

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -10,28 +10,10 @@ pub trait Behavior {}
 /// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
 /// causes it to **overwrite** existing elements from the **front**.
 ///
-/// # Examples
-///
-/// ```text
-/// [_, _, _] + 1 => [_, _, 1] -> None
-/// [_, _, 1] + 2 => [_, 1, 2] -> None
-/// [_, 1, 2] + 3 => [1, 2, 3] -> None
-/// [1, 2, 3] + 4 => [2, 3, 4] -> Some(1)
-/// ```
-///
 /// ### Pushing to front:
 ///
 /// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
 /// causes it to **overwrite** existing elements from the **back**.
-///
-/// # Examples
-///
-/// ```text
-/// 1 + [_, _, _] => [1, _, _] -> None
-/// 2 + [1, _, _] => [2, 1, _] -> None
-/// 3 + [2, 1, _] => [3, 2, 1] -> None
-/// 4 + [3, 2, 1] => [4, 3, 2] -> Some(1)
-/// ```
 pub struct Wrapping;
 impl Behavior for Wrapping {}
 
@@ -42,27 +24,9 @@ impl Behavior for Wrapping {}
 /// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
 /// causes it **exit early, without performing any mutation**.
 ///
-/// # Examples
-///
-/// ```text
-/// [_, _, _] + 1 => [_, _, 1] -> None
-/// [_, _, 1] + 2 => [_, 1, 2] -> None
-/// [_, 1, 2] + 3 => [1, 2, 3] -> None
-/// [1, 2, 3] + 4 => [1, 2, 3] -> Some(4)
-/// ```
-///
 /// ### Pushing to front:
 ///
 /// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
 /// causes it **exit early, without performing any mutation**.
-///
-/// # Examples
-///
-/// ```text
-/// 1 + [_, _, _] => [1, _, _] -> None
-/// 2 + [1, _, _] => [2, 1, _] -> None
-/// 3 + [2, 1, _] => [3, 2, 1] -> None
-/// 4 + [3, 2, 1] => [3, 2, 1] -> Some(4)
-/// ```
 pub struct Saturating;
 impl Behavior for Saturating {}

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -1,0 +1,68 @@
+//! Behavior semantics for `ArrayDeque`.
+
+/// Tagging trait for providing behaviors to `ArrayDeque`.
+pub trait Behavior {}
+
+/// Behavior for `ArrayDeque` that specifies wrapping write semantics.
+///
+/// ### Pushing to back:
+///
+/// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
+/// causes it to **overwrite** existing elements from the **front**.
+///
+/// # Examples
+///
+/// ```text
+/// [_, _, _] + 1 => [_, _, 1] -> None
+/// [_, _, 1] + 2 => [_, 1, 2] -> None
+/// [_, 1, 2] + 3 => [1, 2, 3] -> None
+/// [1, 2, 3] + 4 => [2, 3, 4] -> Some(1)
+/// ```
+///
+/// ### Pushing to front:
+///
+/// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
+/// causes it to **overwrite** existing elements from the **back**.
+///
+/// # Examples
+///
+/// ```text
+/// 1 + [_, _, _] => [1, _, _] -> None
+/// 2 + [1, _, _] => [2, 1, _] -> None
+/// 3 + [2, 1, _] => [3, 2, 1] -> None
+/// 4 + [3, 2, 1] => [4, 3, 2] -> Some(1)
+/// ```
+pub struct Wrapping;
+impl Behavior for Wrapping {}
+
+/// Behavior for `ArrayDeque` that specifies saturating write semantics.
+///
+/// ### Pushing to back:
+///
+/// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
+/// causes it **exit early, without performing any mutation**.
+///
+/// # Examples
+///
+/// ```text
+/// [_, _, _] + 1 => [_, _, 1] -> None
+/// [_, _, 1] + 2 => [_, 1, 2] -> None
+/// [_, 1, 2] + 3 => [1, 2, 3] -> None
+/// [1, 2, 3] + 4 => [1, 2, 3] -> Some(4)
+/// ```
+///
+/// ### Pushing to front:
+///
+/// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
+/// causes it **exit early, without performing any mutation**.
+///
+/// # Examples
+///
+/// ```text
+/// 1 + [_, _, _] => [1, _, _] -> None
+/// 2 + [1, _, _] => [2, 1, _] -> None
+/// 3 + [2, 1, _] => [3, 2, 1] -> None
+/// 4 + [3, 2, 1] => [3, 2, 1] -> Some(4)
+/// ```
+pub struct Saturating;
+impl Behavior for Saturating {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Error type for `ArrayDeque<_, Saturating>`.
+
 use std::fmt;
 #[cfg(feature="std")]
 use std::error::Error;
@@ -5,6 +7,7 @@ use std::error::Error;
 /// Error value indicating insufficient capacity
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct CapacityError<T = ()> {
+    /// The element that caused the error.
     pub element: T,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,30 @@
+use std::fmt;
+#[cfg(feature="std")]
+use std::error::Error;
+
+/// Error value indicating insufficient capacity
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CapacityError<T = ()> {
+    pub element: T,
+}
+
+const CAPERROR: &'static str = "insufficient capacity";
+
+#[cfg(feature="std")]
+impl<T> Error for CapacityError<T> {
+    fn description(&self) -> &str {
+        CAPERROR
+    }
+}
+
+impl<T> fmt::Display for CapacityError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", CAPERROR)
+    }
+}
+
+impl<T> fmt::Debug for CapacityError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", "CapacityError", CAPERROR)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ use std::marker::PhantomData;
 pub use odds::IndexRange as RangeArgument;
 
 mod array;
+mod behavior;
 pub mod error;
 
 pub use array::Array;
@@ -185,62 +186,11 @@ pub trait Behavior {}
 /// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
 /// causes it to **overwrite** existing elements from the **front**.
 ///
-/// # Examples
-///
-/// ```text
-/// [_, _, _] + 1 => [_, _, 1] -> None
-/// [_, _, 1] + 2 => [_, 1, 2] -> None
-/// [_, 1, 2] + 3 => [1, 2, 3] -> None
-/// [1, 2, 3] + 4 => [2, 3, 4] -> Some(1)
-/// ```
-///
 /// ### Pushing to front:
 ///
 /// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
 /// causes it to **overwrite** existing elements from the **back**.
-///
-/// # Examples
-///
-/// ```text
-/// 1 + [_, _, _] => [1, _, _] -> None
-/// 2 + [1, _, _] => [2, 1, _] -> None
-/// 3 + [2, 1, _] => [3, 2, 1] -> None
-/// 4 + [3, 2, 1] => [4, 3, 2] -> Some(1)
-/// ```
-pub struct Wrapping;
-impl Behavior for Wrapping {}
-
-/// Behavior for `ArrayDeque` that specifies saturating write semantics.
-///
-/// ### Pushing to back:
-///
-/// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
-/// causes it **exit early, without performing any mutation**.
-///
-/// # Examples
-///
-/// ```text
-/// [_, _, _] + 1 => [_, _, 1] -> None
-/// [_, _, 1] + 2 => [_, 1, 2] -> None
-/// [_, 1, 2] + 3 => [1, 2, 3] -> None
-/// [1, 2, 3] + 4 => [1, 2, 3] -> Some(4)
-/// ```
-///
-/// ### Pushing to front:
-///
-/// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
-/// causes it **exit early, without performing any mutation**.
-///
-/// # Examples
-///
-/// ```text
-/// 1 + [_, _, _] => [1, _, _] -> None
-/// 2 + [1, _, _] => [2, 1, _] -> None
-/// 3 + [2, 1, _] => [3, 2, 1] -> None
-/// 4 + [3, 2, 1] => [3, 2, 1] -> Some(4)
-/// ```
-pub struct Saturating;
-impl Behavior for Saturating {}
+pub use behavior::{Behavior, Saturating, Wrapping};
 
 unsafe fn new_array<A: Array>() -> A {
     // Note: Returning an uninitialized value here only works
@@ -519,7 +469,7 @@ impl<A: Array, B: Behavior> ArrayDeque<A, B> {
     /// ```
     /// use arraydeque::ArrayDeque;
     ///
-    /// let vector: ArrayDeque<[usize; 2]> = ArrayDeque::new();
+    /// let vector: ArrayDeque<[usize; 3]> = ArrayDeque::new();
     /// ```
     #[inline]
     pub fn new() -> Self {
@@ -543,7 +493,6 @@ impl<A: Array, B: Behavior> ArrayDeque<A, B> {
     /// use arraydeque::ArrayDeque;
     ///
     /// let mut deque: ArrayDeque<[_; 4]> = ArrayDeque::new();
-    ///
     /// deque.push_back(3);
     /// deque.push_back(4);
     /// deque.push_back(5);
@@ -633,7 +582,6 @@ impl<A: Array, B: Behavior> ArrayDeque<A, B> {
     /// ```
     /// use arraydeque::ArrayDeque;
     /// let mut deque: ArrayDeque<[usize; 4]> = ArrayDeque::new();
-    ///
     /// assert_eq!(deque.capacity(), 3);
     /// ```
     ///
@@ -923,7 +871,6 @@ impl<A: Array, B: Behavior> ArrayDeque<A, B> {
     /// let mut deque: ArrayDeque<[_; 3]> = ArrayDeque::new();
     /// assert_eq!(deque.front(), None);
     /// deque.push_back(1);
-    ///
     /// deque.push_back(2);
     /// assert_eq!(deque.front(), Some(&1));
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,15 +178,67 @@ use array::Index as ArrayIndex;
 /// Tagging trait for providing behaviors to `ArrayDeque`.
 pub trait Behavior {}
 
-/// Behavior for `ArrayDeque` that provides wrapping write operations.
+/// Behavior for `ArrayDeque` that specifies wrapping write semantics.
 ///
-/// See `ArrayDeque<_, Wrapping>` for more info.
+/// ### Pushing to back:
+///
+/// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
+/// causes it to **overwrite** existing elements from the **front**.
+///
+/// # Examples
+///
+/// ```text
+/// [_, _, _] + 1 => [_, _, 1] -> None
+/// [_, _, 1] + 2 => [_, 1, 2] -> None
+/// [_, 1, 2] + 3 => [1, 2, 3] -> None
+/// [1, 2, 3] + 4 => [2, 3, 4] -> Some(1)
+/// ```
+///
+/// ### Pushing to front:
+///
+/// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
+/// causes it to **overwrite** existing elements from the **back**.
+///
+/// # Examples
+///
+/// ```text
+/// 1 + [_, _, _] => [1, _, _] -> None
+/// 2 + [1, _, _] => [2, 1, _] -> None
+/// 3 + [2, 1, _] => [3, 2, 1] -> None
+/// 4 + [3, 2, 1] => [4, 3, 2] -> Some(1)
+/// ```
 pub struct Wrapping;
 impl Behavior for Wrapping {}
 
-/// Behavior for `ArrayDeque` that provides saturating write operations.
+/// Behavior for `ArrayDeque` that specifies saturating write semantics.
 ///
-/// See `ArrayDeque<_, Saturating>` for more info.
+/// ### Pushing to back:
+///
+/// Pushing elements to the **back** of a fixed-size deque that **has already reached its capacity**
+/// causes it **exit early, without performing any mutation**.
+///
+/// # Examples
+///
+/// ```text
+/// [_, _, _] + 1 => [_, _, 1] -> None
+/// [_, _, 1] + 2 => [_, 1, 2] -> None
+/// [_, 1, 2] + 3 => [1, 2, 3] -> None
+/// [1, 2, 3] + 4 => [1, 2, 3] -> Some(4)
+/// ```
+///
+/// ### Pushing to front:
+///
+/// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
+/// causes it **exit early, without performing any mutation**.
+///
+/// # Examples
+///
+/// ```text
+/// 1 + [_, _, _] => [1, _, _] -> None
+/// 2 + [1, _, _] => [2, 1, _] -> None
+/// 3 + [2, 1, _] => [3, 2, 1] -> None
+/// 4 + [3, 2, 1] => [3, 2, 1] -> Some(4)
+/// ```
 pub struct Saturating;
 impl Behavior for Saturating {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1618,6 +1618,13 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     ///
     /// # Examples
     ///
+    /// ```text
+    /// 1 -(+)-> [_, _, _] => [1, _, _] -> None
+    /// 2 -(+)-> [1, _, _] => [2, 1, _] -> None
+    /// 3 -(+)-> [2, 1, _] => [3, 2, 1] -> None
+    /// 4 -(+)-> [3, 2, 1] => [3, 2, 1] -> Some(4)
+    /// ```
+    ///
     /// ```
     /// use arraydeque::{ArrayDeque, Saturating};
     ///
@@ -1644,6 +1651,13 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     /// if the vector is full.
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [_, _, _] <-(+)- 1 => [_, _, 1] -> None
+    /// [_, _, 1] <-(+)- 2 => [_, 1, 2] -> None
+    /// [_, 1, 2] <-(+)- 3 => [1, 2, 3] -> None
+    /// [1, 2, 3] <-(+)- 4 => [1, 2, 3] -> Some(4)
+    /// ```
     ///
     /// ```
     /// use arraydeque::{ArrayDeque, Saturating};
@@ -1679,6 +1693,14 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     /// Panics if `index` is greater than `ArrayDeque`'s length
     ///
     /// # Examples
+    ///
+    ///
+    /// ```text
+    /// [0, _, _] <-(+)- 1 @ 0 => [1, 0, _] -> None
+    /// [1, 0, _] <-(+)- 3 @ 1 => [1, 3, 0] -> None
+    /// [1, 3, 0] <-(+)- 2 @ 1 => [1, 3, 0] -> Some(2)
+    /// ```
+    ///
     /// ```
     /// use arraydeque::ArrayDeque;
     ///
@@ -1705,6 +1727,13 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     /// Does not extract more items than there is space for.
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [2, 1] -(+)-> [_, _, _] => [1, 2, _]
+    /// [2, 1] -(+)-> [3, _, _] => [1, 2, 3]
+    /// [2, 1] -(+)-> [3, 4, _] => [2, 3, 4]
+    /// [2, 1] -(+)-> [3, 4, 5] => [3, 4, 5]
+    /// ```
     ///
     /// ```
     /// use arraydeque::{ArrayDeque, Saturating};
@@ -1735,6 +1764,13 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     /// Does not extract more items than there is space for.
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [_, _, _] <-(+)- [2, 1] => [_, 2, 1]
+    /// [_, _, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// [_, 4, 3] <-(+)- [2, 1] => [4, 3, 2]
+    /// [5, 4, 3] <-(+)- [2, 1] => [5, 4, 3]
+    /// ```
     ///
     /// ```
     /// use arraydeque::{ArrayDeque, Saturating};
@@ -1767,6 +1803,13 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     ///
     /// # Examples
     ///
+    /// ```text
+    /// [1, 2] -(+)-> [_, _, _] => [1, 2, _]
+    /// [1, 2] -(+)-> [3, _, _] => [1, 2, 3]
+    /// [1, 2] -(+)-> [3, 4, _] => [2, 3, 4]
+    /// [1, 2] -(+)-> [3, 4, 5] => [3, 4, 5]
+    /// ```
+    ///
     /// ```
     /// use arraydeque::ArrayDeque;
     ///
@@ -1797,6 +1840,11 @@ impl<A: Array> ArrayDeque<A, Saturating> {
     ///
     /// # Examples
     ///
+    /// ```text
+    /// [_, _, _] <-(+)- [2, 1] => [_, 2, 1]
+    /// [_, _, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// [_, 4, 3] <-(+)- [2, 1] => [4, 3, 2]
+    /// [5, 4, 3] <-(+)- [2, 1] => [5, 4, 3]
     /// ```
     /// use arraydeque::ArrayDeque;
     ///
@@ -1835,6 +1883,11 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     ///
     /// # Examples
     ///
+    /// ```text
+    /// 1 -(+)-> [_, _, _] => [1, _, _] -> None
+    /// 2 -(+)-> [1, _, _] => [2, 1, _] -> None
+    /// 3 -(+)-> [2, 1, _] => [3, 2, 1] -> None
+    /// 4 -(+)-> [3, 2, 1] => [4, 3, 2] -> Some(1)
     /// ```
     /// use arraydeque::{ArrayDeque, Wrapping};
     ///
@@ -1862,6 +1915,13 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     /// if the vector is full, where `existing` is the element being overwritten.
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [_, _, _] <-(+)- 1 => [_, _, 1] -> None
+    /// [_, _, 1] <-(+)- 2 => [_, 1, 2] -> None
+    /// [_, 1, 2] <-(+)- 3 => [1, 2, 3] -> None
+    /// [1, 2, 3] <-(+)- 4 => [2, 3, 4] -> Some(1)
+    /// ```
     ///
     /// ```
     /// use arraydeque::{ArrayDeque, Wrapping};
@@ -1898,6 +1958,13 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     /// Panics if `index` is greater than `ArrayDeque`'s length
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [0, _, _] <-(+)- 1 @ 0 => [1, 0, _] -> None
+    /// [1, 0, _] <-(+)- 3 @ 1 => [1, 3, 0] -> None
+    /// [1, 3, 0] <-(+)- 2 @ 1 => [1, 2, 3] -> Some(0)
+    /// ```
+    ///
     /// ```
     /// use arraydeque::ArrayDeque;
     ///
@@ -1925,6 +1992,13 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     /// Extracts all items from `other` overwriting `self` if necessary.
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [2, 1] -(+)-> [_, _, _] => [1, 2, _]
+    /// [2, 1] -(+)-> [3, _, _] => [1, 2, 3]
+    /// [2, 1] -(+)-> [3, 4, _] => [1, 2, 3]
+    /// [2, 1] -(+)-> [3, 4, 5] => [1, 2, 3]
+    /// ```
     ///
     /// ```
     /// use arraydeque::{ArrayDeque, Wrapping};
@@ -1955,6 +2029,13 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     /// 
     /// # Examples
     /// 
+    /// ```text
+    /// [_, _, _] <-(+)- [2, 1] => [_, 2, 1]
+    /// [_, _, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// [_, 4, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// [5, 4, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// ```
+    ///
     /// ```
     /// // use arraydeque::{ArrayDeque, Wrapping};
     /// //
@@ -1984,6 +2065,13 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     ///
     /// # Examples
     ///
+    /// ```text
+    /// [1, 2] -(+)-> [_, _, _] => [1, 2, _]
+    /// [1, 2] -(+)-> [3, _, _] => [1, 2, 3]
+    /// [1, 2] -(+)-> [3, 4, _] => [1, 2, 3]
+    /// [1, 2] -(+)-> [3, 4, 5] => [1, 2, 3]
+    /// ```
+    ///
     /// ```
     /// use arraydeque::ArrayDeque;
     ///
@@ -2011,6 +2099,13 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     /// Extracts all items from `other` overwriting `self` if necessary.
     ///
     /// # Examples
+    ///
+    /// ```text
+    /// [_, _, _] <-(+)- [2, 1] => [_, 2, 1]
+    /// [_, _, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// [_, 4, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// [5, 4, 3] <-(+)- [2, 1] => [3, 2, 1]
+    /// ```
     ///
     /// ```
     /// use arraydeque::ArrayDeque;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2600,21 +2600,21 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 8], $behavior> = ArrayDeque::new();
-        assert_eq!(tester.capacity(), 7);
-        assert_eq!(tester.len(), 0);
+                assert_eq!(tester.capacity(), 7);
+                assert_eq!(tester.len(), 0);
 
-        tester.push_back(1);
-        tester.push_back(2);
-        tester.push_back(3);
-        tester.push_back(4);
-        assert_eq!(tester.len(), 4);
+                tester.push_back(1);
+                tester.push_back(2);
+                tester.push_back(3);
+                tester.push_back(4);
+                assert_eq!(tester.len(), 4);
 
-        assert_eq!(tester.pop_front(), Some(1));
-        assert_eq!(tester.pop_front(), Some(2));
-        assert_eq!(tester.len(), 2);
-        assert_eq!(tester.pop_front(), Some(3));
-        assert_eq!(tester.pop_front(), Some(4));
-        assert_eq!(tester.pop_front(), None);
+                assert_eq!(tester.pop_front(), Some(1));
+                assert_eq!(tester.pop_front(), Some(2));
+                assert_eq!(tester.len(), 2);
+                assert_eq!(tester.pop_front(), Some(3));
+                assert_eq!(tester.pop_front(), Some(4));
+                assert_eq!(tester.pop_front(), None);
             })
         }
 
@@ -2627,20 +2627,20 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 8], $behavior> = ArrayDeque::new();
-        assert_eq!(tester.capacity(), 7);
-        assert_eq!(tester.len(), 0);
+                assert_eq!(tester.capacity(), 7);
+                assert_eq!(tester.len(), 0);
 
-        tester.push_front(1);
-        tester.push_front(2);
-        tester.push_front(3);
-        tester.push_front(4);
-        assert_eq!(tester.len(), 4);
-        assert_eq!(tester.pop_back(), Some(1));
-        assert_eq!(tester.pop_back(), Some(2));
-        assert_eq!(tester.len(), 2);
-        assert_eq!(tester.pop_back(), Some(3));
-        assert_eq!(tester.pop_back(), Some(4));
-        assert_eq!(tester.pop_back(), None);
+                tester.push_front(1);
+                tester.push_front(2);
+                tester.push_front(3);
+                tester.push_front(4);
+                assert_eq!(tester.len(), 4);
+                assert_eq!(tester.pop_back(), Some(1));
+                assert_eq!(tester.pop_back(), Some(2));
+                assert_eq!(tester.len(), 2);
+                assert_eq!(tester.pop_back(), Some(3));
+                assert_eq!(tester.pop_back(), Some(4));
+                assert_eq!(tester.pop_back(), None);
             })
         }
 
@@ -2670,10 +2670,10 @@ mod tests {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 3], $behavior> = ArrayDeque::new();
                 assert_eq!(tester.push_back(1), None);
-        assert_eq!(tester.pop_front(), Some(1));
-        assert_eq!(tester.is_empty(), true);
-        assert_eq!(tester.len(), 0);
-        assert_eq!(tester.pop_front(), None);
+                assert_eq!(tester.pop_front(), Some(1));
+                assert_eq!(tester.is_empty(), true);
+                assert_eq!(tester.len(), 0);
+                assert_eq!(tester.pop_front(), None);
             })
     }
 
@@ -2686,20 +2686,20 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 4], $behavior> = ArrayDeque::new();
-        tester.push_back(1);
-        tester.push_back(2);
-        tester.push_back(3);
-        assert_eq!(tester[0], 1);
-        // pop_front 1 <- [2, 3]
-        assert_eq!(tester.pop_front(), Some(1));
-        assert_eq!(tester[0], 2);
-        assert_eq!(tester.len(), 2);
-        // push_front 0 -> [0, 2, 3]
-        tester.push_front(0);
-        assert_eq!(tester[0], 0);
-        // [0, 2] -> 3 pop_back
-        assert_eq!(tester.pop_back(), Some(3));
-        assert_eq!(tester[1], 2);
+                tester.push_back(1);
+                tester.push_back(2);
+                tester.push_back(3);
+                assert_eq!(tester[0], 1);
+                // pop_front 1 <- [2, 3]
+                assert_eq!(tester.pop_front(), Some(1));
+                assert_eq!(tester[0], 2);
+                assert_eq!(tester.len(), 2);
+                // push_front 0 -> [0, 2, 3]
+                tester.push_front(0);
+                assert_eq!(tester[0], 0);
+                // [0, 2] -> 3 pop_back
+                assert_eq!(tester.pop_back(), Some(3));
+                assert_eq!(tester[1], 2);
             })
         }
 
@@ -2713,11 +2713,11 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 4], $behavior> = ArrayDeque::new();
-        tester.push_back(1);
-        tester.push_back(2);
-        tester[2];
+                tester.push_back(1);
+                tester.push_back(2);
+                tester[2];
             })
-    }
+        }
 
         test!(Saturating);
         test!(Wrapping);
@@ -2728,28 +2728,28 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 3], $behavior> = ArrayDeque::new();
-        tester.push_back(1);
-        tester.push_back(2);
-        {
-            let mut iter = tester.iter();
-            assert_eq!(iter.size_hint(), (2, Some(2)));
-            assert_eq!(iter.next(), Some(&1));
-            assert_eq!(iter.next(), Some(&2));
-            assert_eq!(iter.next(), None);
-            assert_eq!(iter.size_hint(), (0, Some(0)));
-        }
-        tester.pop_front();
-        tester.push_back(3);
-        {
-            let mut iter = (&tester).into_iter();
-            assert_eq!(iter.next(), Some(&2));
+                tester.push_back(1);
+                tester.push_back(2);
+                {
+                    let mut iter = tester.iter();
+                    assert_eq!(iter.size_hint(), (2, Some(2)));
+                    assert_eq!(iter.next(), Some(&1));
+                    assert_eq!(iter.next(), Some(&2));
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.size_hint(), (0, Some(0)));
+                }
+                tester.pop_front();
+                tester.push_back(3);
+                {
+                    let mut iter = (&tester).into_iter();
+                    assert_eq!(iter.next(), Some(&2));
 
-            // test clone
-            let mut iter2 = iter.clone();
-            assert_eq!(iter.next(), Some(&3));
-            assert_eq!(iter.next(), None);
-            assert_eq!(iter2.next(), Some(&3));
-            assert_eq!(iter2.next(), None);
+                    // test clone
+                    let mut iter2 = iter.clone();
+                    assert_eq!(iter.next(), Some(&3));
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter2.next(), Some(&3));
+                    assert_eq!(iter2.next(), None);
                 }
             })
         }
@@ -2763,32 +2763,32 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester: ArrayDeque<[_; 3], $behavior> = ArrayDeque::new();
-        tester.push_back(1);
-        tester.push_back(2);
-        {
-            let mut iter = tester.iter_mut();
-            assert_eq!(iter.size_hint(), (2, Some(2)));
-            assert_eq!(iter.next(), Some(&mut 1));
-            assert_eq!(iter.next(), Some(&mut 2));
-            assert_eq!(iter.next(), None);
-            assert_eq!(iter.size_hint(), (0, Some(0)));
-        }
-        tester.pop_front();
-        tester.push_back(3);
-        {
-            let mut iter = (&mut tester).into_iter();
-            assert_eq!(iter.next(), Some(&mut 2));
-            assert_eq!(iter.next(), Some(&mut 3));
-            assert_eq!(iter.next(), None);
-        }
-        {
-            // mutation
-            let mut iter = tester.iter_mut();
-            iter.next().map(|n| *n += 1);
-            iter.next().map(|n| *n += 2);
-        }
-        assert_eq!(tester[0], 3);
-        assert_eq!(tester[1], 5);
+                tester.push_back(1);
+                tester.push_back(2);
+                {
+                    let mut iter = tester.iter_mut();
+                    assert_eq!(iter.size_hint(), (2, Some(2)));
+                    assert_eq!(iter.next(), Some(&mut 1));
+                    assert_eq!(iter.next(), Some(&mut 2));
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.size_hint(), (0, Some(0)));
+                }
+                tester.pop_front();
+                tester.push_back(3);
+                {
+                    let mut iter = (&mut tester).into_iter();
+                    assert_eq!(iter.next(), Some(&mut 2));
+                    assert_eq!(iter.next(), Some(&mut 3));
+                    assert_eq!(iter.next(), None);
+                }
+                {
+                    // mutation
+                    let mut iter = tester.iter_mut();
+                    iter.next().map(|n| *n += 1);
+                    iter.next().map(|n| *n += 2);
+                }
+                assert_eq!(tester[0], 3);
+                assert_eq!(tester[1], 5);
             })
         }
 
@@ -2803,43 +2803,43 @@ mod tests {
 
         macro_rules! test {
             ($behavior:ident) => ({
-        {
+                {
                     let mut tester: ArrayDeque<[NoCopy<u8>; 3], $behavior> = ArrayDeque::new();
-            tester.push_back(NoCopy(1));
-            tester.push_back(NoCopy(2));
-            let mut iter = tester.into_iter();
-            assert_eq!(iter.size_hint(), (2, Some(2)));
-            assert_eq!(iter.next(), Some(NoCopy(1)));
-            assert_eq!(iter.next(), Some(NoCopy(2)));
-            assert_eq!(iter.next(), None);
-            assert_eq!(iter.size_hint(), (0, Some(0)));
-        }
-        {
-                            let mut tester: ArrayDeque<[NoCopy<u8>; 3], $behavior> = ArrayDeque::new();
-            tester.push_back(NoCopy(1));
-            tester.push_back(NoCopy(2));
-            tester.pop_front();
-            tester.push_back(NoCopy(3));
-            let mut iter = tester.into_iter();
-            assert_eq!(iter.next(), Some(NoCopy(2)));
-            assert_eq!(iter.next(), Some(NoCopy(3)));
-            assert_eq!(iter.next(), None);
-        }
-        {
-                            let mut tester: ArrayDeque<[NoCopy<u8>; 3], $behavior> = ArrayDeque::new();
-            tester.push_back(NoCopy(1));
-            tester.push_back(NoCopy(2));
-            tester.pop_front();
-            tester.push_back(NoCopy(3));
-            tester.pop_front();
-            tester.push_back(NoCopy(4));
-            let mut iter = tester.into_iter();
-            assert_eq!(iter.next(), Some(NoCopy(3)));
-            assert_eq!(iter.next(), Some(NoCopy(4)));
-            assert_eq!(iter.next(), None);
-        }
+                    tester.push_back(NoCopy(1));
+                    tester.push_back(NoCopy(2));
+                    let mut iter = tester.into_iter();
+                    assert_eq!(iter.size_hint(), (2, Some(2)));
+                    assert_eq!(iter.next(), Some(NoCopy(1)));
+                    assert_eq!(iter.next(), Some(NoCopy(2)));
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.size_hint(), (0, Some(0)));
+                }
+                {
+                                    let mut tester: ArrayDeque<[NoCopy<u8>; 3], $behavior> = ArrayDeque::new();
+                    tester.push_back(NoCopy(1));
+                    tester.push_back(NoCopy(2));
+                    tester.pop_front();
+                    tester.push_back(NoCopy(3));
+                    let mut iter = tester.into_iter();
+                    assert_eq!(iter.next(), Some(NoCopy(2)));
+                    assert_eq!(iter.next(), Some(NoCopy(3)));
+                    assert_eq!(iter.next(), None);
+                }
+                {
+                                    let mut tester: ArrayDeque<[NoCopy<u8>; 3], $behavior> = ArrayDeque::new();
+                    tester.push_back(NoCopy(1));
+                    tester.push_back(NoCopy(2));
+                    tester.pop_front();
+                    tester.push_back(NoCopy(3));
+                    tester.pop_front();
+                    tester.push_back(NoCopy(4));
+                    let mut iter = tester.into_iter();
+                    assert_eq!(iter.next(), Some(NoCopy(3)));
+                    assert_eq!(iter.next(), Some(NoCopy(4)));
+                    assert_eq!(iter.next(), None);
+                }
             })
-    }
+        }
 
         test!(Saturating);
         test!(Wrapping);
@@ -2849,30 +2849,30 @@ mod tests {
     fn any_drain() {
         macro_rules! test {
             ($behavior:ident) => ({
-        const CAP: usize = 7;
+                const CAP: usize = 7;
                 let mut tester: ArrayDeque<[_; CAP + 1], $behavior> = ArrayDeque::new();
 
-        for padding in 0..CAP {
-            for drain_start in 0..CAP {
-                for drain_end in drain_start..CAP {
-                    // deque starts from different tail position
-                    unsafe {
-                        tester.set_head(padding);
-                        tester.set_tail(padding);
+                for padding in 0..CAP {
+                    for drain_start in 0..CAP {
+                        for drain_end in drain_start..CAP {
+                            // deque starts from different tail position
+                            unsafe {
+                                tester.set_head(padding);
+                                tester.set_tail(padding);
+                            }
+
+                            tester.extend(0..CAP);
+
+                            let mut expected = vec![0, 1, 2, 3, 4, 5, 6];
+                            let drains: Vec<_> = tester.drain(drain_start..drain_end).collect();
+                            let expected_drains: Vec<_> = expected.drain(drain_start..drain_end).collect();
+                            assert_eq!(drains, expected_drains);
+                            assert_eq!(tester.len(), expected.len());
+                        }
                     }
-
-                    tester.extend(0..CAP);
-
-                    let mut expected = vec![0, 1, 2, 3, 4, 5, 6];
-                    let drains: Vec<_> = tester.drain(drain_start..drain_end).collect();
-                    let expected_drains: Vec<_> = expected.drain(drain_start..drain_end).collect();
-                    assert_eq!(drains, expected_drains);
-                    assert_eq!(tester.len(), expected.len());
                 }
-            }
-        }
             })
-    }
+        }
 
         test!(Saturating);
         test!(Wrapping);
@@ -2960,29 +2960,29 @@ mod tests {
     fn any_as_slice() {
         macro_rules! test {
             ($behavior:ident) => ({
-        const CAP: usize = 10;
+                const CAP: usize = 10;
                 let mut tester = ArrayDeque::<[_; CAP], $behavior>::new();
 
-        for len in 0..CAP - 1 {
-            for padding in 0..CAP {
-                // deque starts from different tail position
-                unsafe {
-                    tester.set_head(padding);
-                    tester.set_tail(padding);
-                }
+                for len in 0..CAP - 1 {
+                    for padding in 0..CAP {
+                        // deque starts from different tail position
+                        unsafe {
+                            tester.set_head(padding);
+                            tester.set_tail(padding);
+                        }
 
-                let mut expected = vec![];
-                tester.extend(0..len);
-                expected.extend(0..len);
+                        let mut expected = vec![];
+                        tester.extend(0..len);
+                        expected.extend(0..len);
 
-                let split_idx = CAP - padding;
-                if split_idx < len {
-                    assert_eq!(tester.as_slices(), expected[..].split_at(split_idx));
-                } else {
-                    assert_eq!(tester.as_slices(), (&expected[..], &[][..]));
+                        let split_idx = CAP - padding;
+                        if split_idx < len {
+                            assert_eq!(tester.as_slices(), expected[..].split_at(split_idx));
+                        } else {
+                            assert_eq!(tester.as_slices(), (&expected[..], &[][..]));
+                        }
+                    }
                 }
-            }
-        }
             })
     }
 
@@ -2994,32 +2994,32 @@ mod tests {
     fn any_partial_equal() {
         macro_rules! test {
             ($behavior:ident) => ({
-        const CAP: usize = 10;
+                const CAP: usize = 10;
                 let mut tester = ArrayDeque::<[f64; CAP], $behavior>::new();
 
-        for len in 0..CAP - 1 {
-            for padding in 0..CAP {
-                // deque starts from different tail position
-                unsafe {
-                    tester.set_head(padding);
-                    tester.set_tail(padding);
-                }
-
-                                let mut expected = ArrayDeque::<[f64; CAP], $behavior>::new();
-                for x in 0..len {
-                    tester.push_back(x as f64);
-                    expected.push_back(x as f64);
-                }
-                assert_eq!(tester, expected);
-
-                // test negative
-                if len > 2 {
-                    tester.pop_front();
-                    expected.pop_back();
-                    assert!(tester != expected);
+                for len in 0..CAP - 1 {
+                    for padding in 0..CAP {
+                        // deque starts from different tail position
+                        unsafe {
+                            tester.set_head(padding);
+                            tester.set_tail(padding);
                         }
+
+                                        let mut expected = ArrayDeque::<[f64; CAP], $behavior>::new();
+                        for x in 0..len {
+                            tester.push_back(x as f64);
+                            expected.push_back(x as f64);
+                        }
+                        assert_eq!(tester, expected);
+
+                        // test negative
+                        if len > 2 {
+                            tester.pop_front();
+                            expected.pop_back();
+                            assert!(tester != expected);
+                        }
+                    }
                 }
-            }
             })
         }
 
@@ -3032,8 +3032,8 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let mut tester = ArrayDeque::<[_; 5], $behavior>::new();
-        tester.extend(0..4);
-        assert_eq!(format!("{:?}", tester), "[0, 1, 2, 3]");
+                tester.extend(0..4);
+                assert_eq!(format!("{:?}", tester), "[0, 1, 2, 3]");
             })
         }
 
@@ -3081,47 +3081,47 @@ mod tests {
     fn any_swap_front_back_remove() {
         macro_rules! test {
             ($behavior:ident) => ({
-        fn test(back: bool) {
-            const CAP: usize = 16;
-                            let mut tester = ArrayDeque::<[_; CAP], $behavior>::new();
-            let usable_cap = tester.capacity();
-            let final_len = usable_cap / 2;
+                fn test(back: bool) {
+                    const CAP: usize = 16;
+                                    let mut tester = ArrayDeque::<[_; CAP], $behavior>::new();
+                    let usable_cap = tester.capacity();
+                    let final_len = usable_cap / 2;
 
-            for len in 0..final_len {
-                        let expected: Vec<_> = if back {
-                    (0..len).collect()
-                } else {
-                    (0..len).rev().collect()
-                };
-                for padding in 0..usable_cap {
-                    unsafe {
-                        tester.set_tail(padding);
-                        tester.set_head(padding);
+                    for len in 0..final_len {
+                                let expected: Vec<_> = if back {
+                            (0..len).collect()
+                        } else {
+                            (0..len).rev().collect()
+                        };
+                        for padding in 0..usable_cap {
+                            unsafe {
+                                tester.set_tail(padding);
+                                tester.set_head(padding);
+                            }
+                            if back {
+                                for i in 0..len * 2 {
+                                    tester.push_front(i);
+                                }
+                                for i in 0..len {
+                                    assert_eq!(tester.swap_remove_back(i), Some(len * 2 - 1 - i));
+                                }
+                            } else {
+                                for i in 0..len * 2 {
+                                    tester.push_back(i);
+                                }
+                                for i in 0..len {
+                                    let idx = tester.len() - 1 - i;
+                                    assert_eq!(tester.swap_remove_front(idx), Some(len * 2 - 1 - i));
+                                }
+                            }
+                            assert!(tester.tail() < CAP);
+                            assert!(tester.head() < CAP);
+                            assert_eq!(tester, expected);
+                        }
                     }
-                    if back {
-                        for i in 0..len * 2 {
-                            tester.push_front(i);
-                        }
-                        for i in 0..len {
-                            assert_eq!(tester.swap_remove_back(i), Some(len * 2 - 1 - i));
-                        }
-                    } else {
-                        for i in 0..len * 2 {
-                            tester.push_back(i);
-                        }
-                        for i in 0..len {
-                            let idx = tester.len() - 1 - i;
-                            assert_eq!(tester.swap_remove_front(idx), Some(len * 2 - 1 - i));
-                        }
-                    }
-                    assert!(tester.tail() < CAP);
-                    assert!(tester.head() < CAP);
-                    assert_eq!(tester, expected);
                 }
-            }
-        }
-        test(true);
-        test(false);
+                test(true);
+                test(false);
             })
         }
 
@@ -3135,14 +3135,14 @@ mod tests {
             ($behavior:ident) => ({
                 const CAP: usize = 11;
                 let mut tester: ArrayDeque<[_; CAP], $behavior> = ArrayDeque::new();
-        for padding in 0..CAP {
-            unsafe {
-                tester.set_tail(padding);
-                tester.set_head(padding);
-            }
-            tester.extend(0..CAP);
-            tester.retain(|x| x % 2 == 0);
-            assert_eq!(tester.iter().count(), CAP / 2);
+                for padding in 0..CAP {
+                    unsafe {
+                        tester.set_tail(padding);
+                        tester.set_head(padding);
+                    }
+                    tester.extend(0..CAP);
+                    tester.retain(|x| x % 2 == 0);
+                    assert_eq!(tester.iter().count(), CAP / 2);
                 }
             })
         }
@@ -3323,26 +3323,26 @@ mod tests {
     fn any_split_off() {
         macro_rules! test {
             ($behavior:ident) => ({
-        const CAP: usize = 16;
+                const CAP: usize = 16;
                 let mut tester = ArrayDeque::<[_; CAP], $behavior>::new();
-        for len in 0..CAP {
-            // index to split at
-            for at in 0..len + 1 {
-                for padding in 0..CAP {
-                            let expected_self: Vec<_> = (0..).take(at).collect();
-                            let expected_other: Vec<_> = (at..).take(len - at).collect();
-                    unsafe {
-                        tester.set_head(padding);
-                        tester.set_tail(padding);
-                    }
-                    for i in 0..len {
-                        tester.push_back(i);
-                    }
-                    let result = tester.split_off(at);
-                    assert!(tester.tail() < CAP);
-                    assert!(tester.head() < CAP);
-                    assert!(result.tail() < CAP);
-                    assert!(result.head() < CAP);
+                for len in 0..CAP {
+                    // index to split at
+                    for at in 0..len + 1 {
+                        for padding in 0..CAP {
+                                    let expected_self: Vec<_> = (0..).take(at).collect();
+                                    let expected_other: Vec<_> = (at..).take(len - at).collect();
+                            unsafe {
+                                tester.set_head(padding);
+                                tester.set_tail(padding);
+                            }
+                            for i in 0..len {
+                                tester.push_back(i);
+                            }
+                            let result = tester.split_off(at);
+                            assert!(tester.tail() < CAP);
+                            assert!(tester.head() < CAP);
+                            assert!(result.tail() < CAP);
+                            assert!(result.head() < CAP);
                             assert_eq!(tester, &expected_self[..]);
                             assert_eq!(result, &expected_other[..]);
                         }
@@ -3417,35 +3417,35 @@ mod tests {
     fn any_remove() {
         macro_rules! test {
             ($behavior:ident) => ({
-        const CAP: usize = 16;
+                const CAP: usize = 16;
                 let mut tester = ArrayDeque::<[_; CAP], $behavior>::new();
 
-        // len is the length *after* removal
-        for len in 0..CAP - 1 {
-            // 0, 1, 2, .., len - 1
-                    let expected: Vec<_> = (0..).take(len).collect();
-            for padding in 0..CAP {
-                for to_remove in 0..len + 1 {
-                    unsafe {
-                        tester.set_tail(padding);
-                        tester.set_head(padding);
-                    }
-                    for i in 0..len {
-                        if i == to_remove {
-                            tester.push_back(1234);
+                // len is the length *after* removal
+                for len in 0..CAP - 1 {
+                    // 0, 1, 2, .., len - 1
+                            let expected: Vec<_> = (0..).take(len).collect();
+                    for padding in 0..CAP {
+                        for to_remove in 0..len + 1 {
+                            unsafe {
+                                tester.set_tail(padding);
+                                tester.set_head(padding);
+                            }
+                            for i in 0..len {
+                                if i == to_remove {
+                                    tester.push_back(1234);
+                                }
+                                tester.push_back(i);
+                            }
+                            if to_remove == len {
+                                tester.push_back(1234);
+                            }
+                            tester.remove(to_remove);
+                            assert!(tester.tail() < CAP);
+                            assert!(tester.head() < CAP);
+                            assert_eq!(tester, expected);
                         }
-                        tester.push_back(i);
                     }
-                    if to_remove == len {
-                        tester.push_back(1234);
-                    }
-                    tester.remove(to_remove);
-                    assert!(tester.tail() < CAP);
-                    assert!(tester.head() < CAP);
-                    assert_eq!(tester, expected);
-                        }
                 }
-            }
             })
         }
 
@@ -3458,8 +3458,8 @@ mod tests {
         macro_rules! test {
             ($behavior:ident) => ({
                 let tester: ArrayDeque<[_; 16], $behavior> = (0..16).into_iter().collect();
-        let cloned = tester.clone();
-        assert_eq!(tester, cloned)
+                let cloned = tester.clone();
+                assert_eq!(tester, cloned)
             })
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,6 @@ pub use array::Array;
 pub use error::CapacityError;
 use array::Index as ArrayIndex;
 
-/// Tagging trait for providing behaviors to `ArrayDeque`.
-pub trait Behavior {}
-
 /// Behavior for `ArrayDeque` that specifies wrapping write semantics.
 ///
 /// ### Pushing to back:
@@ -191,14 +188,6 @@ pub trait Behavior {}
 /// Pushing elements to the **front** of a fixed-size deque that **has already reached its capacity**
 /// causes it to **overwrite** existing elements from the **back**.
 pub use behavior::{Behavior, Saturating, Wrapping};
-
-unsafe fn new_array<A: Array>() -> A {
-    // Note: Returning an uninitialized value here only works
-    // if we can be sure the data is never used. The nullable pointer
-    // inside enum optimization conflicts with this this for example,
-    // so we need to be extra careful. See `NoDrop` enum.
-    mem::uninitialized()
-}
 
 /// A fixed capacity ring buffer.
 ///
@@ -2024,11 +2013,11 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     }
 
     /// Iterates over the iterator's items, adding them to the back of the deque, one by one.
-    /// 
+    ///
     /// Extracts all items from `other` overwriting `self` if necessary.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```text
     /// [_, _, _] <-(+)- [2, 1] => [_, 2, 1]
     /// [_, _, 3] <-(+)- [2, 1] => [3, 2, 1]
@@ -2297,7 +2286,7 @@ impl<'a, A: Array, B: Behavior> IntoIterator for &'a mut ArrayDeque<A, B> {
 impl<A: Array> Extend<A::Item> for ArrayDeque<A, Saturating> {
     fn extend<T: IntoIterator<Item = A::Item>>(&mut self, iter: T) {
         let take = self.capacity() - self.len();
-        for elt in iter.into_iter().take(take) {            
+        for elt in iter.into_iter().take(take) {
             self.push_back(elt);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3439,7 +3439,7 @@ mod test_generic_array {
     use generic_array::GenericArray;
     use generic_array::typenum::U41;
 
-    use super::ArrayDeque;
+    use super::*;
 
     #[test]
     fn any_simple() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2037,21 +2037,21 @@ impl<A: Array> ArrayDeque<A, Wrapping> {
     /// ```
     ///
     /// ```
-    /// // use arraydeque::{ArrayDeque, Wrapping};
-    /// //
-    /// // let mut deque: ArrayDeque<[_; 8], Wrapping> = vec![9, 8, 7].into_iter().collect();
-    /// // let mut vec1 = vec![6, 5, 4];
-    /// // let mut vec2 = vec![3, 2, 1];
-    /// //
-    /// // deque.extend_back(vec1);
-    /// // assert_eq!(deque.len(), 6);
-    /// //
-    /// // // max capacity reached
-    /// // deque.extend_back(vec2);
-    /// // assert_eq!(deque.len(), 7);
-    /// // let collected: Vec<_> = deque.into_iter().collect();
-    /// // let expected = vec![7, 6, 5, 4, 3, 2, 1];
-    /// // assert_eq!(collected, expected);
+    /// use arraydeque::{ArrayDeque, Wrapping};
+    ///
+    /// let mut deque: ArrayDeque<[_; 8], Wrapping> = vec![9, 8, 7].into_iter().collect();
+    /// let mut vec1 = vec![6, 5, 4];
+    /// let mut vec2 = vec![3, 2, 1];
+    ///
+    /// deque.extend_back(vec1);
+    /// assert_eq!(deque.len(), 6);
+    ///
+    /// // max capacity reached
+    /// deque.extend_back(vec2);
+    /// assert_eq!(deque.len(), 7);
+    /// let collected: Vec<_> = deque.into_iter().collect();
+    /// let expected = vec![7, 6, 5, 4, 3, 2, 1];
+    /// assert_eq!(collected, expected);
     /// ```
     pub fn extend_back<T: IntoIterator<Item = A::Item>>(&mut self, iter: T) {
         for element in iter.into_iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,8 @@
 
 #![cfg_attr(not(any(feature="std", test)), no_std)]
 
+#![deny(missing_docs)]
+
 extern crate odds;
 // #![cfg_attr(not(or(feature="std", test), no_std))]
 #[cfg(not(any(feature="std", test)))]


### PR DESCRIPTION
Attempts to resolve issue https://github.com/andylokandy/arraydeque/issues/6 according to:

> - Add a type parameter on `ArrayDeuqe`, determining whether to enable wrapping behavior, which would look like `ArrayDeque<[usize; 64], Wrapping>`, and disable as default.

Curious as to what you think about it, @andylokandy. 🙂
Consider this a work-in-progress.

Sorry for the big commit. The type change forced me to touch basically everything before it compiled again.