### PR TITLE
Changed access API of `Array` trait from raw pointer to slice

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,5 +1,7 @@
 //! Fixed-size arrays.
 
+use std::slice;
+
 /// Trait for fixed size arrays.
 pub unsafe trait Array {
     /// The array’s element type
@@ -11,6 +13,18 @@ pub unsafe trait Array {
     fn as_ptr(&self) -> *const Self::Item;
     #[doc(hidden)]
     fn as_mut_ptr(&mut self) -> *mut Self::Item;
+    #[doc(hidden)]
+    #[inline(always)]
+    fn as_slice(&self) -> &[Self::Item] {
+        let ptr = self as *const _ as *const _;
+        unsafe { slice::from_raw_parts(ptr, Self::capacity()) }
+    }
+    #[doc(hidden)]
+    #[inline(always)]
+    fn as_mut_slice(&mut self) -> &mut [Self::Item] {
+        let ptr = self as *mut _ as *mut _;
+        unsafe { slice::from_raw_parts_mut(ptr, Self::capacity()) }
+    }
     #[doc(hidden)]
     fn capacity() -> usize;
 }
@@ -26,7 +40,7 @@ impl Index for u8 {
     fn to_usize(self) -> usize {
         self as usize
     }
-    
+
     #[inline(always)]
     fn from(ix: usize) -> Self {
         ix as u8

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ use std::hash::{Hash, Hasher};
 use std::marker;
 use std::fmt;
 use std::ptr;
-use std::slice;
 use std::iter::FromIterator;
 use std::ops::Index;
 use std::ops::IndexMut;
@@ -987,12 +986,12 @@ impl<A: Array, B: Behavior> ArrayDeque<A, B> {
 
     #[inline]
     unsafe fn buffer_as_slice(&self) -> &[A::Item] {
-        slice::from_raw_parts(self.ptr(), A::capacity())
+        self.xs.as_slice()
     }
 
     #[inline]
     unsafe fn buffer_as_mut_slice(&mut self) -> &mut [A::Item] {
-        slice::from_raw_parts_mut(self.ptr_mut(), A::capacity())
+        self.xs.as_mut_slice()
     }
 
     #[inline]


### PR DESCRIPTION
The [`Array` trait](https://github.com/andylokandy/arraydeque/blob/master/src/array.rs#L11-L13) is defined like this:

```rust
/// Trait for fixed size arrays.
pub unsafe trait Array {
    // ...
    fn as_ptr(&self) -> *const Self::Item;
    fn as_mut_ptr(&mut self) -> *mut Self::Item;
    // ...
}
```

This made me curious as to why you chose to use this, instead of the safer

```rust
/// Trait for fixed size arrays.
pub unsafe trait Array {
    // ...
    fn as_slice(&self) -> &[T];
    fn as_mut_slice(&mut self) -> &mut [T];
    // ...
}
```
?

## Motivation

I have an implementation of a median filter that's making use of `ArrayDeque<[T; N], Wrapping>` like so:

```rust
pub struct Filter<A>
where
    A: Array,
{
    buffer: ArrayDeque<A, Wrapping>,
    sorted_buffer: A,
}

impl<A> Filter<A>
where
    A: Array,
    A::Item: Ord + Clone,
{
    pub fn new() -> Self {
        Filter {
            buffer: ArrayDeque::new(),
            sorted_buffer: unsafe { mem::uninitialized() },
        }
    }

    pub fn consume(&mut self, value: A::Item) -> A::Item {
        use std::slice::from_raw_parts_mut;

        self.buffer.push_back(value);
        let size = self.buffer.len();

        let buffer_ptr = (&mut self.sorted_buffer).as_mut_ptr();
        let slice = unsafe { from_raw_parts_mut(buffer_ptr, size) };

        for (index, item) in self.buffer.iter().enumerate() {
            slice[index] = item.clone();
        }

        slice.sort();

        let median_index = (size - 1) / 2;
        slice[median_index].clone()
    }
}
```

If `Array` was depending on slices instead of raw pointers I could replace these ugly and unsafe bits

```rust
let buffer_ptr = (&mut self.sorted_buffer).as_mut_ptr();
let slice = unsafe { from_raw_parts_mut(buffer_ptr, size) };
```

with this

```rust
let slice = (&mut self.sorted_buffer).as_mut_slice();
```

I reckon this is a problem that's common enough to justify such a change, no?
And after all we wouldn't be losing much, as getting a pointer out of a slice is trivial and safe. The opposite direction however is not.