### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First, add the following to your `Cargo.toml`:
 arraydeque = "0.5"
 ```
 
-Next, add this to your crate root:
+If you use the 2015 rust edition, add this to your crate root:
 
 ```rust
 extern crate arraydeque;


### PR DESCRIPTION
The `extern crate <crate_name>` isn't necessary since the 2018 edition.